### PR TITLE
build: bump version to 0.1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.williamcallahan"
-version = findProperty("version")?.toString()?.takeIf { it != "unspecified" } ?: "0.1.7"
+version = findProperty("version")?.toString()?.takeIf { it != "unspecified" } ?: "0.1.8"
 
 java {
     toolchain {


### PR DESCRIPTION
## Summary

The v0.1.7 tag was pushed before the Homebrew formula hardening fixes landed in PR #29, so the release workflow ran with the old broken sed patterns. The tap is still stuck at v0.1.5.1. Bumping to v0.1.8 so a new tag triggers the fixed workflow.

## Changes

### Maintenance
- **Version bump 0.1.7 → 0.1.8**: Enables a fresh release that will run the hardened workflow and correctly update the Homebrew formula (`build.gradle.kts` line 7)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Version bumped from 0.1.7 to 0.1.8 to trigger the release workflow with the hardened formula update fixes from PR #29. The v0.1.7 tag was pushed before the workflow improvements landed, causing the Homebrew tap to remain stuck at v0.1.5.1. This bump ensures the next release will run with the corrected sed patterns and validation checks.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — single-line version bump with clear purpose
- The change is a straightforward version increment that only modifies the default version string in `build.gradle.kts`. The rationale is well-documented in the PR description, and the change aligns with the workflow hardening completed in PR #29. No functional code changes or risk of regression.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| build.gradle.kts | Version bumped from 0.1.7 to 0.1.8 to trigger fixed release workflow |

</details>



<sub>Last reviewed commit: c7388e0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->