### PR TITLE
fix(chat): paste works in prompts, native terminal selection is default, and composer line colors stay themed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 # Gradle
 .gradle
 .gradle-user-home/
+.gradle-local/
 !gradle/wrapper/gradle-wrapper.jar
 
 # Kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.williamcallahan"
-version = findProperty("version")?.toString()?.takeIf { it != "unspecified" } ?: "0.1.8"
+version = findProperty("version")?.toString()?.takeIf { it != "unspecified" } ?: "0.2.0"
 
 java {
     toolchain {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,12 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.2")
 }
 
+tasks.processResources {
+    filesMatching("version.properties") {
+        expand("version" to project.version)
+    }
+}
+
 tasks.test {
     useJUnitPlatform()
 }

--- a/docs/environment-variables-api-keys.md
+++ b/docs/environment-variables-api-keys.md
@@ -38,7 +38,7 @@ config.priority=env
 | Variable | Values | Description |
 |----------|--------|-------------|
 | `BRIEF_ALT_SCREEN` | `1` | Alternate screen buffer (clears on exit) |
-| `BRIEF_MOUSE` | `all`, `btn`, `off` | Mouse tracking mode |
+| `BRIEF_MOUSE` | `0`/`off`/`native`, `1`/`all`, `wheel`/`btn`, `select` | Mouse tracking mode (default: `0`) |
 | `BRIEF_SHOW_TOOLS` | `1` | Show tool call messages |
 
 ## Alternative Providers

--- a/src/main/java/com/williamcallahan/chatclient/AppInfo.java
+++ b/src/main/java/com/williamcallahan/chatclient/AppInfo.java
@@ -1,9 +1,23 @@
 package com.williamcallahan.chatclient;
 
+import java.io.IOException;
+import java.util.Properties;
+
 /** Application metadata constants. */
 public final class AppInfo {
     public static final String NAME = "brief";
-    public static final String VERSION = "v0.1.4";
+    public static final String VERSION = loadVersion();
 
     private AppInfo() {}
+
+    private static String loadVersion() {
+        var props = new Properties();
+        try (var in = AppInfo.class.getResourceAsStream("/version.properties")) {
+            if (in != null) {
+                props.load(in);
+                return "v" + props.getProperty("app.version", "unknown");
+            }
+        } catch (IOException ignored) {}
+        return "v-unknown";
+    }
 }

--- a/src/main/java/com/williamcallahan/chatclient/Main.java
+++ b/src/main/java/com/williamcallahan/chatclient/Main.java
@@ -41,15 +41,12 @@ public class Main {
         // Set BRIEF_ALT_SCREEN=1 to enable the alternate screen.
         boolean useAlt = "1".equals(System.getenv("BRIEF_ALT_SCREEN"));
         // Mouse behavior:
-        // - unset: in-app drag-to-copy selection + wheel scroll (viewport-locked)
-        // - 0: native terminal selection/copy (no in-app wheel scrolling)
-        // - 1: tui4j mouse all-motion tracking (best wheel support; most terminals disable native selection)
-        // - wheel: wheel/click tracking only (often more compatible with native selection depending on terminal)
-        // - select: wheel + drag tracking; app copies selected lines (native selection disabled)
-        String mouseMode = System.getenv("BRIEF_MOUSE");
-        if (mouseMode == null || mouseMode.isBlank()) {
-            mouseMode = "select";
-        }
+        // - default/unset: native terminal selection/copy (no in-app wheel scrolling)
+        // - 0/off/native: native terminal selection/copy
+        // - 1/all: tui4j all-motion tracking (best wheel support; native selection usually disabled)
+        // - wheel/btn: wheel + click tracking (no drag-to-copy selection)
+        // - select: in-app drag-to-copy selection + wheel scrolling
+        String mouseMode = resolveMouseMode();
         // Default ON: disable terminal autowrap so full-width borders don't soft-wrap at the last column.
         // Set BRIEF_AUTOWRAP=1 to keep terminal default wrapping behavior.
         boolean disableAutoWrap = !"1".equals(System.getenv("BRIEF_AUTOWRAP"));
@@ -69,7 +66,8 @@ public class Main {
         // Terminal mode setup - only after config validation succeeds
         boolean enableSelectMouse = "select".equalsIgnoreCase(mouseMode);
         boolean enableAllMotionMouse = "1".equals(mouseMode);
-        boolean enableCellMotionMouse = enableSelectMouse;
+        boolean enableCellMotionMouse =
+            enableSelectMouse || "wheel".equals(mouseMode);
 
         if (disableAutoWrap) {
             System.out.print(DISABLE_AUTOWRAP);
@@ -162,5 +160,23 @@ public class Main {
         } catch (IllegalArgumentException e) {
             LOG.log(Level.FINE, "SIGCONT not available on this platform", e);
         }
+    }
+
+    static String normalizeMouseMode(String rawMode) {
+        if (rawMode == null || rawMode.isBlank()) {
+            return "0";
+        }
+        String mode = rawMode.trim().toLowerCase();
+        return switch (mode) {
+            case "0", "off", "native", "false" -> "0";
+            case "1", "all", "true" -> "1";
+            case "wheel", "btn", "buttons" -> "wheel";
+            case "select" -> "select";
+            default -> "0";
+        };
+    }
+
+    private static String resolveMouseMode() {
+        return normalizeMouseMode(System.getenv("BRIEF_MOUSE"));
     }
 }

--- a/src/main/java/com/williamcallahan/chatclient/ui/ApiKeyPromptScreen.java
+++ b/src/main/java/com/williamcallahan/chatclient/ui/ApiKeyPromptScreen.java
@@ -68,7 +68,7 @@ public class ApiKeyPromptScreen extends ConfigPromptScreen {
         }
 
         Conversation convo = convoBuilder.build();
-        ChatConversationScreen next = new ChatConversationScreen(
+        ChatConversationScreen chatScreen = new ChatConversationScreen(
             name,
             convo,
             config,
@@ -76,6 +76,7 @@ public class ApiKeyPromptScreen extends ConfigPromptScreen {
             height,
             needsModelSelection
         );
+        Model next = new PasteRoutingModel(chatScreen);
         return UpdateResult.from(
             next,
             batch(

--- a/src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java
+++ b/src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java
@@ -5,12 +5,14 @@ import com.williamcallahan.chatclient.Config;
 import com.williamcallahan.tui4j.compat.bubbletea.Command;
 import com.williamcallahan.tui4j.compat.bubbletea.Message;
 import com.williamcallahan.tui4j.compat.bubbletea.Model;
+import com.williamcallahan.tui4j.compat.bubbletea.PasteMessage;
 import com.williamcallahan.tui4j.compat.bubbletea.UpdateResult;
 import com.williamcallahan.tui4j.compat.lipgloss.Position;
 import com.williamcallahan.tui4j.compat.lipgloss.border.StandardBorder;
 import com.williamcallahan.tui4j.compat.lipgloss.Style;
 import com.williamcallahan.tui4j.compat.bubbletea.input.key.KeyAliases;
 import com.williamcallahan.tui4j.compat.bubbletea.input.key.KeyAliases.KeyAlias;
+import com.williamcallahan.tui4j.compat.bubbletea.input.key.Key;
 import com.williamcallahan.tui4j.compat.bubbletea.KeyPressMessage;
 import com.williamcallahan.tui4j.compat.bubbletea.input.key.KeyType;
 import com.williamcallahan.tui4j.compat.bubbletea.QuitMessage;
@@ -68,6 +70,10 @@ public abstract class ConfigPromptScreen implements Model {
             return UpdateResult.from(this);
         }
 
+        if (msg instanceof PasteMessage paste) {
+            return handlePaste(paste.content());
+        }
+
         if (msg instanceof KeyPressMessage key) {
             if (KeyAliases.getKeyType(KeyAlias.KeyEnter) == key.type()) {
                 return onSubmit(textInput.value());
@@ -80,6 +86,40 @@ public abstract class ConfigPromptScreen implements Model {
 
         UpdateResult<? extends Model> r = textInput.update(msg);
         return UpdateResult.from(this, r.command());
+    }
+
+    private UpdateResult<? extends Model> handlePaste(String content) {
+        if (content == null || content.isEmpty()) {
+            return UpdateResult.from(this);
+        }
+
+        String normalized = normalizeSingleLinePaste(content);
+        if (normalized.isEmpty()) {
+            return UpdateResult.from(this);
+        }
+
+        KeyPressMessage pasteAsRunes = new KeyPressMessage(
+            new Key(KeyType.KeyRunes, normalized.toCharArray())
+        );
+        UpdateResult<? extends Model> inputUpdate = textInput.update(pasteAsRunes);
+        return UpdateResult.from(this, inputUpdate.command());
+    }
+
+    private static String normalizeSingleLinePaste(String content) {
+        StringBuilder normalized = new StringBuilder(content.length());
+        boolean lastInsertedSpace = false;
+        for (char ch : content.toCharArray()) {
+            if (ch == '\r' || ch == '\n' || ch == '\t' || ch < 32) {
+                if (!lastInsertedSpace) {
+                    normalized.append(' ');
+                    lastInsertedSpace = true;
+                }
+                continue;
+            }
+            normalized.append(ch);
+            lastInsertedSpace = (ch == ' ');
+        }
+        return normalized.toString();
     }
 
     @Override
@@ -128,4 +168,3 @@ public abstract class ConfigPromptScreen implements Model {
         return s.indent(spaces).stripTrailing();
     }
 }
-

--- a/src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java
+++ b/src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java
@@ -1,0 +1,194 @@
+package com.williamcallahan.chatclient.ui;
+
+import com.williamcallahan.chatclient.ui.maps.PlacesOverlay;
+import com.williamcallahan.tui4j.compat.bubbles.textarea.Textarea;
+import com.williamcallahan.tui4j.compat.bubbletea.Command;
+import com.williamcallahan.tui4j.compat.bubbletea.KeyPressMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.Message;
+import com.williamcallahan.tui4j.compat.bubbletea.Model;
+import com.williamcallahan.tui4j.compat.bubbletea.PasteMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.UpdateResult;
+import com.williamcallahan.tui4j.compat.bubbletea.input.key.Key;
+import com.williamcallahan.tui4j.compat.bubbletea.input.key.KeyType;
+import com.williamcallahan.tui4j.compat.lipgloss.Style;
+import com.williamcallahan.tui4j.input.MouseTarget;
+import com.williamcallahan.tui4j.input.MouseTargetProvider;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Wraps a model and reroutes paste into key runes for single-line overlay inputs
+ * that do not currently handle {@link PasteMessage}.
+ */
+final class PasteRoutingModel implements Model, MouseTargetProvider {
+
+    @FunctionalInterface
+    interface PasteRoutingStrategy {
+        boolean shouldRoutePasteAsRunes(Model model);
+    }
+
+    private static final Field CHAT_COMPOSER_FIELD =
+        resolveField(ChatConversationScreen.class, "composer");
+    private static final PasteRoutingStrategy CHAT_PLACES_INPUT_STRATEGY =
+        new ChatPlacesInputStrategy();
+
+    private Model delegate;
+    private final PasteRoutingStrategy pasteRoutingStrategy;
+
+    PasteRoutingModel(Model delegate) {
+        this(delegate, CHAT_PLACES_INPUT_STRATEGY);
+    }
+
+    PasteRoutingModel(Model delegate, PasteRoutingStrategy pasteRoutingStrategy) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.pasteRoutingStrategy = Objects.requireNonNull(
+            pasteRoutingStrategy,
+            "pasteRoutingStrategy"
+        );
+        applyDelegateStyleOverrides(this.delegate);
+    }
+
+    @Override
+    public Command init() {
+        return delegate.init();
+    }
+
+    @Override
+    public UpdateResult<? extends Model> update(Message msg) {
+        if (
+            msg instanceof PasteMessage paste &&
+            shouldRoutePasteAsRunes(paste.content())
+        ) {
+            UpdateResult<? extends Model> routed = routePasteAsRunes(
+                paste.content()
+            );
+            delegate = routed.model();
+            return UpdateResult.from(this, routed.command());
+        }
+
+        UpdateResult<? extends Model> result = delegate.update(msg);
+        delegate = result.model();
+        applyDelegateStyleOverrides(delegate);
+        return UpdateResult.from(this, result.command());
+    }
+
+    @Override
+    public String view() {
+        return delegate.view();
+    }
+
+    @Override
+    public List<MouseTarget> mouseTargets() {
+        if (delegate instanceof MouseTargetProvider provider) {
+            return provider.mouseTargets();
+        }
+        return List.of();
+    }
+
+    private boolean shouldRoutePasteAsRunes(String content) {
+        if (content == null || content.isEmpty()) {
+            return false;
+        }
+        return pasteRoutingStrategy.shouldRoutePasteAsRunes(delegate);
+    }
+
+    private UpdateResult<? extends Model> routePasteAsRunes(String content) {
+        String normalized = normalizeForSingleLineInput(content);
+        if (normalized.isEmpty()) {
+            return UpdateResult.from(delegate);
+        }
+
+        KeyPressMessage pasteAsRunes = new KeyPressMessage(
+            new Key(KeyType.KeyRunes, normalized.toCharArray())
+        );
+        return delegate.update(pasteAsRunes);
+    }
+
+    static String normalizeForSingleLineInput(String content) {
+        StringBuilder normalized = new StringBuilder(content.length());
+        boolean lastInsertedSpace = false;
+        for (char ch : content.toCharArray()) {
+            if (ch == '\r' || ch == '\n' || ch == '\t' || ch < 32) {
+                if (!lastInsertedSpace) {
+                    normalized.append(' ');
+                    lastInsertedSpace = true;
+                }
+                continue;
+            }
+            normalized.append(ch);
+            lastInsertedSpace = (ch == ' ');
+        }
+        return normalized.toString();
+    }
+
+    static void applyComposerStyles(Textarea composer) {
+        if (composer == null) {
+            return;
+        }
+        applyTextareaStyle(composer.focusedStyle());
+        applyTextareaStyle(composer.blurredStyle());
+        applyTextareaStyle(composer.style());
+    }
+
+    private void applyDelegateStyleOverrides(Model model) {
+        if (
+            !(model instanceof ChatConversationScreen) ||
+            CHAT_COMPOSER_FIELD == null
+        ) {
+            return;
+        }
+        try {
+            Textarea composer = (Textarea) CHAT_COMPOSER_FIELD.get(model);
+            applyComposerStyles(composer);
+        } catch (IllegalAccessException | ClassCastException ignored) {}
+    }
+
+    private static void applyTextareaStyle(Textarea.Style style) {
+        style
+            .base(Style.newStyle())
+            .prompt(TuiTheme.inputPrompt())
+            .text(Style.newStyle().foreground(TuiTheme.PRIMARY))
+            .cursorLine(Style.newStyle().foreground(TuiTheme.PRIMARY))
+            .placeholder(TuiTheme.hint());
+    }
+
+    private static Field resolveField(Class<?> type, String fieldName) {
+        try {
+            Field field = type.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field;
+        } catch (NoSuchFieldException e) {
+            return null;
+        }
+    }
+
+    private static final class ChatPlacesInputStrategy
+        implements PasteRoutingStrategy
+    {
+
+        private static final Field PLACES_OVERLAY_FIELD =
+            resolveField(ChatConversationScreen.class, "placesOverlay");
+
+        @Override
+        public boolean shouldRoutePasteAsRunes(Model model) {
+            if (!(model instanceof ChatConversationScreen)) {
+                return false;
+            }
+            if (PLACES_OVERLAY_FIELD == null) {
+                return false;
+            }
+            try {
+                PlacesOverlay overlay = (PlacesOverlay) PLACES_OVERLAY_FIELD.get(
+                    model
+                );
+                return (
+                    overlay != null && overlay.isOpen() && overlay.isInputMode()
+                );
+            } catch (IllegalAccessException | ClassCastException e) {
+                return false;
+            }
+        }
+
+    }
+}

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+app.version=${version}

--- a/src/test/java/com/williamcallahan/chatclient/MainMouseModeTest.java
+++ b/src/test/java/com/williamcallahan/chatclient/MainMouseModeTest.java
@@ -1,0 +1,26 @@
+package com.williamcallahan.chatclient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MainMouseModeTest {
+
+    @Test
+    void defaultsToNativeWhenUnsetOrUnknown() {
+        assertEquals("0", Main.normalizeMouseMode(null));
+        assertEquals("0", Main.normalizeMouseMode(""));
+        assertEquals("0", Main.normalizeMouseMode("unknown"));
+    }
+
+    @Test
+    void normalizesMouseAliases() {
+        assertEquals("0", Main.normalizeMouseMode("off"));
+        assertEquals("0", Main.normalizeMouseMode("native"));
+        assertEquals("1", Main.normalizeMouseMode("all"));
+        assertEquals("1", Main.normalizeMouseMode("1"));
+        assertEquals("wheel", Main.normalizeMouseMode("btn"));
+        assertEquals("wheel", Main.normalizeMouseMode("wheel"));
+        assertEquals("select", Main.normalizeMouseMode("select"));
+    }
+}

--- a/src/test/java/com/williamcallahan/chatclient/ui/ConfigPromptScreenPasteTest.java
+++ b/src/test/java/com/williamcallahan/chatclient/ui/ConfigPromptScreenPasteTest.java
@@ -1,0 +1,47 @@
+package com.williamcallahan.chatclient.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.williamcallahan.chatclient.Config;
+import com.williamcallahan.tui4j.compat.bubbletea.Model;
+import com.williamcallahan.tui4j.compat.bubbletea.PasteMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.UpdateResult;
+import org.junit.jupiter.api.Test;
+
+class ConfigPromptScreenPasteTest {
+
+    @Test
+    void pasteInsertsSanitizedSingleLineText() {
+        PromptScreenUnderTest prompt = new PromptScreenUnderTest();
+
+        prompt.update(new PasteMessage("sk-test\r\nline-two\tline-three"));
+
+        assertEquals("sk-test line-two line-three", prompt.currentValue());
+    }
+
+    private static final class PromptScreenUnderTest extends ConfigPromptScreen {
+
+        private PromptScreenUnderTest() {
+            super(new Config(), "placeholder", 256);
+        }
+
+        @Override
+        protected String promptTitle() {
+            return "title";
+        }
+
+        @Override
+        protected String promptBody() {
+            return "body";
+        }
+
+        @Override
+        protected UpdateResult<? extends Model> onSubmit(String value) {
+            return UpdateResult.from(this);
+        }
+
+        private String currentValue() {
+            return textInput.value();
+        }
+    }
+}

--- a/src/test/java/com/williamcallahan/chatclient/ui/PasteRoutingModelTest.java
+++ b/src/test/java/com/williamcallahan/chatclient/ui/PasteRoutingModelTest.java
@@ -1,0 +1,92 @@
+package com.williamcallahan.chatclient.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.williamcallahan.tui4j.compat.bubbles.textarea.Textarea;
+import com.williamcallahan.tui4j.compat.bubbletea.Command;
+import com.williamcallahan.tui4j.compat.bubbletea.KeyPressMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.Message;
+import com.williamcallahan.tui4j.compat.bubbletea.Model;
+import com.williamcallahan.tui4j.compat.bubbletea.PasteMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.UpdateResult;
+import com.williamcallahan.tui4j.compat.lipgloss.color.NoColor;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class PasteRoutingModelTest {
+
+    @Test
+    void routesPasteToRunesWhenStrategySaysToRoute() {
+        RecordingModel delegate = new RecordingModel();
+        PasteRoutingModel model = new PasteRoutingModel(delegate, ignored -> true);
+
+        model.update(new PasteMessage("coffee\nshop"));
+
+        KeyPressMessage keyPress = assertInstanceOf(
+            KeyPressMessage.class,
+            delegate.lastMessage
+        );
+        assertEquals("coffee shop", new String(keyPress.runes()));
+    }
+
+    @Test
+    void leavesPasteUntouchedWhenStrategyDeclinesRoute() {
+        RecordingModel delegate = new RecordingModel();
+        PasteRoutingModel model = new PasteRoutingModel(delegate, ignored -> false);
+
+        model.update(new PasteMessage("coffee"));
+
+        assertInstanceOf(PasteMessage.class, delegate.lastMessage);
+    }
+
+    @Test
+    void applyComposerStylesClearsFocusedCursorLineBackground() {
+        Textarea composer = new Textarea();
+        Object before = styleBackground(composer.focusedStyle().cursorLine());
+        assertFalse(before instanceof NoColor);
+
+        PasteRoutingModel.applyComposerStyles(composer);
+
+        Object after = styleBackground(composer.focusedStyle().cursorLine());
+        assertTrue(after instanceof NoColor);
+    }
+
+    private static final class RecordingModel implements Model {
+
+        private Message lastMessage;
+
+        @Override
+        public Command init() {
+            return null;
+        }
+
+        @Override
+        public UpdateResult<? extends Model> update(Message msg) {
+            lastMessage = msg;
+            return UpdateResult.from(this);
+        }
+
+        @Override
+        public String view() {
+            return "";
+        }
+    }
+
+    private static Object styleBackground(
+        com.williamcallahan.tui4j.compat.lipgloss.Style style
+    ) {
+        try {
+            Field background = style.getClass().getDeclaredField("background");
+            background.setAccessible(true);
+            return background.get(style);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                "Unable to inspect style background",
+                e
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes the terminal input regressions so paste works where users enter config and place-search text, right-click/native terminal copy-paste behavior works by default again, and the chat composer no longer shows a black active-line strip. It also aligns runtime/build version metadata and bumps the project release version to `0.2.0`.

## Changes

### Bug Fixes
- **Pasted config/API-key text now inserts reliably**: prompt screens convert `PasteMessage` input into sanitized single-line rune input, so multiline clipboard content no longer gets dropped (`ConfigPromptScreen.update`, `ConfigPromptScreen.handlePaste` in `src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java`).
- **Places overlay input now accepts paste like typed text**: paste events are routed into rune updates when the places overlay is open in input mode (`PasteRoutingModel.update`, `ChatPlacesInputStrategy.shouldRoutePasteAsRunes` in `src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java`).
- **Composer input row now keeps app/terminal background color**: focused cursor-line background override is cleared so the active line no longer renders as black (`PasteRoutingModel.applyComposerStyles`, `PasteRoutingModel.applyTextareaStyle` in `src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java`).
- **Native terminal selection/paste is now the default mouse behavior**: unset or unknown `BRIEF_MOUSE` values normalize to native mode (`0`), restoring expected terminal copy/paste affordances (`Main.normalizeMouseMode` in `src/main/java/com/williamcallahan/chatclient/Main.java`).

### Documentation
- **Mouse-mode docs now match runtime aliases/defaults**: environment variable docs were updated so users can choose `native`, `all`, `wheel/btn`, or `select` with correct default semantics (`docs/environment-variables-api-keys.md`).

### Build / Release
- **Runtime version label now comes from build metadata**: app version is loaded from `version.properties` and injected during resource processing to prevent hardcoded version drift (`AppInfo.loadVersion` in `src/main/java/com/williamcallahan/chatclient/AppInfo.java`, `tasks.processResources` in `build.gradle.kts`, `src/main/resources/version.properties`).
- **Default release version is bumped to the next minor**: project fallback version advances to `0.2.0` (`build.gradle.kts`).
- **Local Gradle cache is no longer shown as repo noise**: `.gradle-local/` is ignored to keep local build cache artifacts out of git status (`.gitignore`).

## Breaking Changes
None

## Validation
- `GRADLE_USER_HOME=.gradle-local ./gradlew test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes terminal paste behavior across config prompts and the places overlay, changes the default mouse mode to preserve native terminal copy/paste, removes the black background from the composer's active line, and bumps the app version to 0.2.0.

**Key Changes:**
- Config and API key prompts now normalize pasted multi-line content to single-line input
- Places overlay paste is routed through `PasteRoutingModel` wrapper to handle paste as runes
- Composer textarea styles are reset to remove black cursor-line background
- Default `BRIEF_MOUSE` changed from "select" to "0" (native mode) with new alias normalization
- Runtime version now loaded from `version.properties` filtered by Gradle

**Minor Issue:**
- Single-line paste normalization logic is duplicated between `ConfigPromptScreen` and `PasteRoutingModel` (violates DRY1 style guideline)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are well-tested with new unit tests, fixes are localized to input handling and styling, default mouse mode change improves UX, and the only issue is minor code duplication that doesn't affect functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/main/java/com/williamcallahan/chatclient/Main.java | changed default `BRIEF_MOUSE` mode from "select" to "0" (native) and added normalization logic with aliases |
| src/main/java/com/williamcallahan/chatclient/ui/ApiKeyPromptScreen.java | wrapped `ChatConversationScreen` in `PasteRoutingModel` to enable paste handling and style fixes |
| src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java | added `PasteMessage` handling with single-line normalization; has code duplication with `PasteRoutingModel` |
| src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java | new wrapper model that routes paste to runes for places overlay and applies composer styles to remove black background |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Pastes Text] --> B{Input Context?}
    B -->|Config/API Prompt| C[ConfigPromptScreen.handlePaste]
    B -->|Places Overlay Open| D[PasteRoutingModel.update]
    B -->|Chat Composer| E[Delegate to ChatConversationScreen]
    
    C --> F[normalizeSingleLinePaste]
    D --> G{Strategy.shouldRoutePasteAsRunes?}
    G -->|Yes - Places Input Mode| H[normalizeForSingleLineInput]
    G -->|No| I[Pass PasteMessage unchanged]
    
    F --> J[Convert to KeyPressMessage with runes]
    H --> J
    J --> K[TextInput receives normalized input]
    I --> L[Delegate handles PasteMessage]
    
    M[ApiKeyPromptScreen.transitionToChat] --> N[Wrap ChatConversationScreen in PasteRoutingModel]
    N --> O[applyComposerStyles - Clear black background]
```

[![Fix All in Claude Code](https://img.shields.io/badge/Fix_All_in_claude-black?logo=claude&logoColor=%23D97706)](https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fmain%2Fjava%2Fcom%2Fwilliamcallahan%2Fchatclient%2Fui%2FConfigPromptScreen.java%3A108-123%0Aduplicates%20%60PasteRoutingModel.normalizeForSingleLineInput%60%20-%20extract%20to%20shared%20utility%20%28violates%20DRY1%29%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20static%20String%20normalizeSingleLinePaste%28String%20content%29%20%7B%0A%20%20%20%20%20%20%20%20return%20PasteRoutingModel.normalizeForSingleLineInput%28content%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A**Context%20Used%3A**%20Context%20from%20%60dashboard%60%20-%20AGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D7dea7316-3cfc-45d2-bc9e-a46f5a9cd855%29%29%0A%0A&repo=williamagh%2Fbrief) [![Fix All in Cursor](https://img.shields.io/badge/Fix_All_in_cursor-black?logo=cursor&logoColor=white)](https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fmain%2Fjava%2Fcom%2Fwilliamcallahan%2Fchatclient%2Fui%2FConfigPromptScreen.java%3A108-123%0Aduplicates%20%60PasteRoutingModel.normalizeForSingleLineInput%60%20-%20extract%20to%20shared%20utility%20%28violates%20DRY1%29%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20static%20String%20normalizeSingleLinePaste%28String%20content%29%20%7B%0A%20%20%20%20%20%20%20%20return%20PasteRoutingModel.normalizeForSingleLineInput%28content%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A**Context%20Used%3A**%20Context%20from%20%60dashboard%60%20-%20AGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D7dea7316-3cfc-45d2-bc9e-a46f5a9cd855%29%29%0A%0A) [![Fix All in Codex](https://img.shields.io/badge/Fix_All_in_codex-black?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0yMi4yODIgOS44MjFhNS45ODUgNS45ODUgMCAwIDAtLjUxNi00LjkxIDYuMDQ2IDYuMDQ2IDAgMCAwLTYuNTEtMi45QTYuMDY1IDYuMDY1IDAgMCAwIDQuOTgxIDQuMThhNS45ODUgNS45ODUgMCAwIDAtMy45OTggMi45IDYuMDQ2IDYuMDQ2IDAgMCAwIC43NDMgNy4wOTcgNS45OCA1Ljk4IDAgMCAwIC41MSA0LjkxMSA2LjA1MSA2LjA1MSAwIDAgMCA2LjUxNSAyLjlBNS45ODUgNS45ODUgMCAwIDAgMTMuMjYgMjRhNi4wNTYgNi4wNTYgMCAwIDAgNS43NzItNC4yMDYgNS45OSA1Ljk5IDAgMCAwIDMuOTk3LTIuOSA2LjA1NiA2LjA1NiAwIDAgMC0uNzQ3LTcuMDczek0xMy4yNiAyMi40M2E0LjQ3NiA0LjQ3NiAwIDAgMS0yLjg3Ni0xLjA0bC4xNDEtLjA4MSA0Ljc3OS0yLjc1OGEuNzk1Ljc5NSAwIDAgMCAuMzkyLS42ODF2LTYuNzM3bDIuMDIgMS4xNjhhLjA3MS4wNzEgMCAwIDEgLjAzOC4wNTJ2NS41ODNhNC41MDQgNC41MDQgMCAwIDEtNC40OTQgNC40OTR6TTMuNiAxOC4zMDRhNC40NyA0LjQ3IDAgMCAxLS41MzUtMy4wMTRsLjE0Mi4wODUgNC43ODMgMi43NTlhLjc3MS43NzEgMCAwIDAgLjc4IDBsNS44NDMtMy4zNjl2Mi4zMzJhLjA4LjA4IDAgMCAxLS4wMzMuMDYyTDkuNzQgMTkuOTVhNC41IDQuNSAwIDAgMS02LjE0LTEuNjQ2ek0yLjM0IDcuODk2YTQuNDg1IDQuNDg1IDAgMCAxIDIuMzY2LTEuOTczVjExLjZhLjc2Ni43NjYgMCAwIDAgLjM4OC42NzZsNS44MTUgMy4zNTUtMi4wMiAxLjE2OGEuMDc2LjA3NiAwIDAgMS0uMDcxIDBsLTQuODMtMi43ODZBNC41MDQgNC41MDQgMCAwIDEgMi4zNCA3Ljg3MnptMTYuNTk3IDMuODU1bC01LjgzMy0zLjM4N0wxNS4xMTkgNy4yYS4wNzYuMDc2IDAgMCAxIC4wNzEgMGw0LjgzIDIuNzkxYTQuNDk0IDQuNDk0IDAgMCAxLS42NzYgOC4xMDV2LTUuNjc4YS43OS43OSAwIDAgMC0uNDA3LS42Njd6bTIuMDEtMy4wMjNsLS4xNDEtLjA4NS00Ljc3NC0yLjc4MmEuNzc2Ljc3NiAwIDAgMC0uNzg1IDBMOS40MDkgOS4yM1Y2Ljg5N2EuMDY2LjA2NiAwIDAgMSAuMDI4LS4wNjFsNC44My0yLjc4N2E0LjUgNC41IDAgMCAxIDYuNjggNC42NnptLTEyLjY0IDQuMTM1bC0yLjAyLTEuMTY0YS4wOC4wOCAwIDAgMS0uMDM4LS4wNTdWNi4wNzVhNC41IDQuNSAwIDAgMSA3LjM3NS0zLjQ1M2wtLjE0Mi4wOEw4LjcwNCA1LjQ2YS43OTUuNzk1IDAgMCAwLS4zOTMuNjgxem0xLjA5Ny0yLjM2NWwyLjYwMi0xLjUgMi42MDcgMS41djIuOTk5bC0yLjU5NyAxLjUtMi42MDctMS41eiIvPjwvc3ZnPg==&logoColor=white)](https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fmain%2Fjava%2Fcom%2Fwilliamcallahan%2Fchatclient%2Fui%2FConfigPromptScreen.java%3A108-123%0Aduplicates%20%60PasteRoutingModel.normalizeForSingleLineInput%60%20-%20extract%20to%20shared%20utility%20%28violates%20DRY1%29%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20static%20String%20normalizeSingleLinePaste%28String%20content%29%20%7B%0A%20%20%20%20%20%20%20%20return%20PasteRoutingModel.normalizeForSingleLineInput%28content%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A**Context%20Used%3A**%20Context%20from%20%60dashboard%60%20-%20AGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D7dea7316-3cfc-45d2-bc9e-a46f5a9cd855%29%29%0A%0A&repo=williamagh%2Fbrief)

<sub>Last reviewed commit: 4433dc4</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=7dea7316-3cfc-45d2-bc9e-a46f5a9cd855))

<!-- /greptile_comment -->