### PR TITLE
fix(chat): restore terminal paste behavior and harden input normalization for v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 # Gradle
 .gradle
 .gradle-user-home/
+.gradle-local/
 !gradle/wrapper/gradle-wrapper.jar
 
 # Kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.williamcallahan"
-version = findProperty("version")?.toString()?.takeIf { it != "unspecified" } ?: "0.1.8"
+version = findProperty("version")?.toString()?.takeIf { it != "unspecified" } ?: "0.2.0"
 
 java {
     toolchain {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,12 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.2")
 }
 
+tasks.processResources {
+    filesMatching("version.properties") {
+        expand("version" to project.version)
+    }
+}
+
 tasks.test {
     useJUnitPlatform()
 }

--- a/docs/environment-variables-api-keys.md
+++ b/docs/environment-variables-api-keys.md
@@ -38,7 +38,7 @@ config.priority=env
 | Variable | Values | Description |
 |----------|--------|-------------|
 | `BRIEF_ALT_SCREEN` | `1` | Alternate screen buffer (clears on exit) |
-| `BRIEF_MOUSE` | `all`, `btn`, `off` | Mouse tracking mode |
+| `BRIEF_MOUSE` | `0`/`off`/`native`, `1`/`all`, `wheel`/`btn`, `select` | Mouse tracking mode (default: `0`) |
 | `BRIEF_SHOW_TOOLS` | `1` | Show tool call messages |
 
 ## Alternative Providers

--- a/docs/environment-variables-api-keys.md
+++ b/docs/environment-variables-api-keys.md
@@ -38,7 +38,7 @@ config.priority=env
 | Variable | Values | Description |
 |----------|--------|-------------|
 | `BRIEF_ALT_SCREEN` | `1` | Alternate screen buffer (clears on exit) |
-| `BRIEF_MOUSE` | `0`/`off`/`native`, `1`/`all`, `wheel`/`btn`, `select` | Mouse tracking mode (default: `0`) |
+| `BRIEF_MOUSE` | `0`/`off`/`native`/`false`, `1`/`all`/`true`, `wheel`/`btn`/`buttons`, `select` | Mouse tracking mode (default: `0`) |
 | `BRIEF_SHOW_TOOLS` | `1` | Show tool call messages |
 
 ## Alternative Providers

--- a/src/main/java/com/williamcallahan/chatclient/AppInfo.java
+++ b/src/main/java/com/williamcallahan/chatclient/AppInfo.java
@@ -1,9 +1,23 @@
 package com.williamcallahan.chatclient;
 
+import java.io.IOException;
+import java.util.Properties;
+
 /** Application metadata constants. */
 public final class AppInfo {
     public static final String NAME = "brief";
-    public static final String VERSION = "v0.1.4";
+    public static final String VERSION = loadVersion();
 
     private AppInfo() {}
+
+    private static String loadVersion() {
+        var props = new Properties();
+        try (var in = AppInfo.class.getResourceAsStream("/version.properties")) {
+            if (in != null) {
+                props.load(in);
+                return "v" + props.getProperty("app.version", "unknown");
+            }
+        } catch (IOException ignored) {}
+        return "v-unknown";
+    }
 }

--- a/src/main/java/com/williamcallahan/chatclient/Main.java
+++ b/src/main/java/com/williamcallahan/chatclient/Main.java
@@ -41,15 +41,12 @@ public class Main {
         // Set BRIEF_ALT_SCREEN=1 to enable the alternate screen.
         boolean useAlt = "1".equals(System.getenv("BRIEF_ALT_SCREEN"));
         // Mouse behavior:
-        // - unset: in-app drag-to-copy selection + wheel scroll (viewport-locked)
-        // - 0: native terminal selection/copy (no in-app wheel scrolling)
-        // - 1: tui4j mouse all-motion tracking (best wheel support; most terminals disable native selection)
-        // - wheel: wheel/click tracking only (often more compatible with native selection depending on terminal)
-        // - select: wheel + drag tracking; app copies selected lines (native selection disabled)
-        String mouseMode = System.getenv("BRIEF_MOUSE");
-        if (mouseMode == null || mouseMode.isBlank()) {
-            mouseMode = "select";
-        }
+        // - default/unset: native terminal selection/copy (no in-app wheel scrolling)
+        // - 0/off/native: native terminal selection/copy
+        // - 1/all: tui4j all-motion tracking (best wheel support; native selection usually disabled)
+        // - wheel/btn: wheel + click tracking (no drag-to-copy selection)
+        // - select: in-app drag-to-copy selection + wheel scrolling
+        String mouseMode = resolveMouseMode();
         // Default ON: disable terminal autowrap so full-width borders don't soft-wrap at the last column.
         // Set BRIEF_AUTOWRAP=1 to keep terminal default wrapping behavior.
         boolean disableAutoWrap = !"1".equals(System.getenv("BRIEF_AUTOWRAP"));
@@ -69,7 +66,8 @@ public class Main {
         // Terminal mode setup - only after config validation succeeds
         boolean enableSelectMouse = "select".equalsIgnoreCase(mouseMode);
         boolean enableAllMotionMouse = "1".equals(mouseMode);
-        boolean enableCellMotionMouse = enableSelectMouse;
+        boolean enableCellMotionMouse =
+            enableSelectMouse || "wheel".equals(mouseMode);
 
         if (disableAutoWrap) {
             System.out.print(DISABLE_AUTOWRAP);
@@ -162,5 +160,23 @@ public class Main {
         } catch (IllegalArgumentException e) {
             LOG.log(Level.FINE, "SIGCONT not available on this platform", e);
         }
+    }
+
+    static String normalizeMouseMode(String rawMode) {
+        if (rawMode == null || rawMode.isBlank()) {
+            return "0";
+        }
+        String mode = rawMode.trim().toLowerCase();
+        return switch (mode) {
+            case "0", "off", "native", "false" -> "0";
+            case "1", "all", "true" -> "1";
+            case "wheel", "btn", "buttons" -> "wheel";
+            case "select" -> "select";
+            default -> "0";
+        };
+    }
+
+    private static String resolveMouseMode() {
+        return normalizeMouseMode(System.getenv("BRIEF_MOUSE"));
     }
 }

--- a/src/main/java/com/williamcallahan/chatclient/ui/ApiKeyPromptScreen.java
+++ b/src/main/java/com/williamcallahan/chatclient/ui/ApiKeyPromptScreen.java
@@ -68,7 +68,7 @@ public class ApiKeyPromptScreen extends ConfigPromptScreen {
         }
 
         Conversation convo = convoBuilder.build();
-        ChatConversationScreen next = new ChatConversationScreen(
+        ChatConversationScreen chatScreen = new ChatConversationScreen(
             name,
             convo,
             config,
@@ -76,6 +76,7 @@ public class ApiKeyPromptScreen extends ConfigPromptScreen {
             height,
             needsModelSelection
         );
+        Model next = new PasteRoutingModel(chatScreen);
         return UpdateResult.from(
             next,
             batch(

--- a/src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java
+++ b/src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java
@@ -5,12 +5,14 @@ import com.williamcallahan.chatclient.Config;
 import com.williamcallahan.tui4j.compat.bubbletea.Command;
 import com.williamcallahan.tui4j.compat.bubbletea.Message;
 import com.williamcallahan.tui4j.compat.bubbletea.Model;
+import com.williamcallahan.tui4j.compat.bubbletea.PasteMessage;
 import com.williamcallahan.tui4j.compat.bubbletea.UpdateResult;
 import com.williamcallahan.tui4j.compat.lipgloss.Position;
 import com.williamcallahan.tui4j.compat.lipgloss.border.StandardBorder;
 import com.williamcallahan.tui4j.compat.lipgloss.Style;
 import com.williamcallahan.tui4j.compat.bubbletea.input.key.KeyAliases;
 import com.williamcallahan.tui4j.compat.bubbletea.input.key.KeyAliases.KeyAlias;
+import com.williamcallahan.tui4j.compat.bubbletea.input.key.Key;
 import com.williamcallahan.tui4j.compat.bubbletea.KeyPressMessage;
 import com.williamcallahan.tui4j.compat.bubbletea.input.key.KeyType;
 import com.williamcallahan.tui4j.compat.bubbletea.QuitMessage;
@@ -68,6 +70,10 @@ public abstract class ConfigPromptScreen implements Model {
             return UpdateResult.from(this);
         }
 
+        if (msg instanceof PasteMessage paste) {
+            return handlePaste(paste.content());
+        }
+
         if (msg instanceof KeyPressMessage key) {
             if (KeyAliases.getKeyType(KeyAlias.KeyEnter) == key.type()) {
                 return onSubmit(textInput.value());
@@ -80,6 +86,40 @@ public abstract class ConfigPromptScreen implements Model {
 
         UpdateResult<? extends Model> r = textInput.update(msg);
         return UpdateResult.from(this, r.command());
+    }
+
+    private UpdateResult<? extends Model> handlePaste(String content) {
+        if (content == null || content.isEmpty()) {
+            return UpdateResult.from(this);
+        }
+
+        String normalized = normalizeSingleLinePaste(content);
+        if (normalized.isEmpty()) {
+            return UpdateResult.from(this);
+        }
+
+        KeyPressMessage pasteAsRunes = new KeyPressMessage(
+            new Key(KeyType.KeyRunes, normalized.toCharArray())
+        );
+        UpdateResult<? extends Model> inputUpdate = textInput.update(pasteAsRunes);
+        return UpdateResult.from(this, inputUpdate.command());
+    }
+
+    private static String normalizeSingleLinePaste(String content) {
+        StringBuilder normalized = new StringBuilder(content.length());
+        boolean lastInsertedSpace = false;
+        for (char ch : content.toCharArray()) {
+            if (ch == '\r' || ch == '\n' || ch == '\t' || ch < 32) {
+                if (!lastInsertedSpace) {
+                    normalized.append(' ');
+                    lastInsertedSpace = true;
+                }
+                continue;
+            }
+            normalized.append(ch);
+            lastInsertedSpace = (ch == ' ');
+        }
+        return normalized.toString();
     }
 
     @Override
@@ -128,4 +168,3 @@ public abstract class ConfigPromptScreen implements Model {
         return s.indent(spaces).stripTrailing();
     }
 }
-

--- a/src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java
+++ b/src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java
@@ -93,7 +93,9 @@ public abstract class ConfigPromptScreen implements Model {
             return UpdateResult.from(this);
         }
 
-        String normalized = normalizeSingleLinePaste(content);
+        String normalized = PasteRoutingModel.normalizeForSingleLineInput(
+            content
+        );
         if (normalized.isEmpty()) {
             return UpdateResult.from(this);
         }
@@ -103,23 +105,6 @@ public abstract class ConfigPromptScreen implements Model {
         );
         UpdateResult<? extends Model> inputUpdate = textInput.update(pasteAsRunes);
         return UpdateResult.from(this, inputUpdate.command());
-    }
-
-    private static String normalizeSingleLinePaste(String content) {
-        StringBuilder normalized = new StringBuilder(content.length());
-        boolean lastInsertedSpace = false;
-        for (char ch : content.toCharArray()) {
-            if (ch == '\r' || ch == '\n' || ch == '\t' || ch < 32) {
-                if (!lastInsertedSpace) {
-                    normalized.append(' ');
-                    lastInsertedSpace = true;
-                }
-                continue;
-            }
-            normalized.append(ch);
-            lastInsertedSpace = (ch == ' ');
-        }
-        return normalized.toString();
     }
 
     @Override

--- a/src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java
+++ b/src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java
@@ -1,0 +1,194 @@
+package com.williamcallahan.chatclient.ui;
+
+import com.williamcallahan.chatclient.ui.maps.PlacesOverlay;
+import com.williamcallahan.tui4j.compat.bubbles.textarea.Textarea;
+import com.williamcallahan.tui4j.compat.bubbletea.Command;
+import com.williamcallahan.tui4j.compat.bubbletea.KeyPressMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.Message;
+import com.williamcallahan.tui4j.compat.bubbletea.Model;
+import com.williamcallahan.tui4j.compat.bubbletea.PasteMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.UpdateResult;
+import com.williamcallahan.tui4j.compat.bubbletea.input.key.Key;
+import com.williamcallahan.tui4j.compat.bubbletea.input.key.KeyType;
+import com.williamcallahan.tui4j.compat.lipgloss.Style;
+import com.williamcallahan.tui4j.input.MouseTarget;
+import com.williamcallahan.tui4j.input.MouseTargetProvider;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Wraps a model and reroutes paste into key runes for single-line overlay inputs
+ * that do not currently handle {@link PasteMessage}.
+ */
+final class PasteRoutingModel implements Model, MouseTargetProvider {
+
+    @FunctionalInterface
+    interface PasteRoutingStrategy {
+        boolean shouldRoutePasteAsRunes(Model model);
+    }
+
+    private static final Field CHAT_COMPOSER_FIELD =
+        resolveField(ChatConversationScreen.class, "composer");
+    private static final PasteRoutingStrategy CHAT_PLACES_INPUT_STRATEGY =
+        new ChatPlacesInputStrategy();
+
+    private Model delegate;
+    private final PasteRoutingStrategy pasteRoutingStrategy;
+
+    PasteRoutingModel(Model delegate) {
+        this(delegate, CHAT_PLACES_INPUT_STRATEGY);
+    }
+
+    PasteRoutingModel(Model delegate, PasteRoutingStrategy pasteRoutingStrategy) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.pasteRoutingStrategy = Objects.requireNonNull(
+            pasteRoutingStrategy,
+            "pasteRoutingStrategy"
+        );
+        applyDelegateStyleOverrides(this.delegate);
+    }
+
+    @Override
+    public Command init() {
+        return delegate.init();
+    }
+
+    @Override
+    public UpdateResult<? extends Model> update(Message msg) {
+        if (
+            msg instanceof PasteMessage paste &&
+            shouldRoutePasteAsRunes(paste.content())
+        ) {
+            UpdateResult<? extends Model> routed = routePasteAsRunes(
+                paste.content()
+            );
+            delegate = routed.model();
+            return UpdateResult.from(this, routed.command());
+        }
+
+        UpdateResult<? extends Model> result = delegate.update(msg);
+        delegate = result.model();
+        applyDelegateStyleOverrides(delegate);
+        return UpdateResult.from(this, result.command());
+    }
+
+    @Override
+    public String view() {
+        return delegate.view();
+    }
+
+    @Override
+    public List<MouseTarget> mouseTargets() {
+        if (delegate instanceof MouseTargetProvider provider) {
+            return provider.mouseTargets();
+        }
+        return List.of();
+    }
+
+    private boolean shouldRoutePasteAsRunes(String content) {
+        if (content == null || content.isEmpty()) {
+            return false;
+        }
+        return pasteRoutingStrategy.shouldRoutePasteAsRunes(delegate);
+    }
+
+    private UpdateResult<? extends Model> routePasteAsRunes(String content) {
+        String normalized = normalizeForSingleLineInput(content);
+        if (normalized.isEmpty()) {
+            return UpdateResult.from(delegate);
+        }
+
+        KeyPressMessage pasteAsRunes = new KeyPressMessage(
+            new Key(KeyType.KeyRunes, normalized.toCharArray())
+        );
+        return delegate.update(pasteAsRunes);
+    }
+
+    static String normalizeForSingleLineInput(String content) {
+        StringBuilder normalized = new StringBuilder(content.length());
+        boolean lastInsertedSpace = false;
+        for (char ch : content.toCharArray()) {
+            if (ch == '\r' || ch == '\n' || ch == '\t' || ch < 32) {
+                if (!lastInsertedSpace) {
+                    normalized.append(' ');
+                    lastInsertedSpace = true;
+                }
+                continue;
+            }
+            normalized.append(ch);
+            lastInsertedSpace = (ch == ' ');
+        }
+        return normalized.toString();
+    }
+
+    static void applyComposerStyles(Textarea composer) {
+        if (composer == null) {
+            return;
+        }
+        applyTextareaStyle(composer.focusedStyle());
+        applyTextareaStyle(composer.blurredStyle());
+        applyTextareaStyle(composer.style());
+    }
+
+    private void applyDelegateStyleOverrides(Model model) {
+        if (
+            !(model instanceof ChatConversationScreen) ||
+            CHAT_COMPOSER_FIELD == null
+        ) {
+            return;
+        }
+        try {
+            Textarea composer = (Textarea) CHAT_COMPOSER_FIELD.get(model);
+            applyComposerStyles(composer);
+        } catch (IllegalAccessException | ClassCastException ignored) {}
+    }
+
+    private static void applyTextareaStyle(Textarea.Style style) {
+        style
+            .base(Style.newStyle())
+            .prompt(TuiTheme.inputPrompt())
+            .text(Style.newStyle().foreground(TuiTheme.PRIMARY))
+            .cursorLine(Style.newStyle().foreground(TuiTheme.PRIMARY))
+            .placeholder(TuiTheme.hint());
+    }
+
+    private static Field resolveField(Class<?> type, String fieldName) {
+        try {
+            Field field = type.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field;
+        } catch (NoSuchFieldException e) {
+            return null;
+        }
+    }
+
+    private static final class ChatPlacesInputStrategy
+        implements PasteRoutingStrategy
+    {
+
+        private static final Field PLACES_OVERLAY_FIELD =
+            resolveField(ChatConversationScreen.class, "placesOverlay");
+
+        @Override
+        public boolean shouldRoutePasteAsRunes(Model model) {
+            if (!(model instanceof ChatConversationScreen)) {
+                return false;
+            }
+            if (PLACES_OVERLAY_FIELD == null) {
+                return false;
+            }
+            try {
+                PlacesOverlay overlay = (PlacesOverlay) PLACES_OVERLAY_FIELD.get(
+                    model
+                );
+                return (
+                    overlay != null && overlay.isOpen() && overlay.isInputMode()
+                );
+            } catch (IllegalAccessException | ClassCastException e) {
+                return false;
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java
+++ b/src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java
@@ -64,6 +64,7 @@ final class PasteRoutingModel implements Model, MouseTargetProvider {
                 paste.content()
             );
             delegate = routed.model();
+            applyDelegateStyleOverrides(delegate);
             return UpdateResult.from(this, routed.command());
         }
 
@@ -119,7 +120,7 @@ final class PasteRoutingModel implements Model, MouseTargetProvider {
             normalized.append(ch);
             lastInsertedSpace = (ch == ' ');
         }
-        return normalized.toString();
+        return normalized.toString().trim();
     }
 
     static void applyComposerStyles(Textarea composer) {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+app.version=${version}

--- a/src/test/java/com/williamcallahan/chatclient/MainMouseModeTest.java
+++ b/src/test/java/com/williamcallahan/chatclient/MainMouseModeTest.java
@@ -1,0 +1,26 @@
+package com.williamcallahan.chatclient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MainMouseModeTest {
+
+    @Test
+    void defaultsToNativeWhenUnsetOrUnknown() {
+        assertEquals("0", Main.normalizeMouseMode(null));
+        assertEquals("0", Main.normalizeMouseMode(""));
+        assertEquals("0", Main.normalizeMouseMode("unknown"));
+    }
+
+    @Test
+    void normalizesMouseAliases() {
+        assertEquals("0", Main.normalizeMouseMode("off"));
+        assertEquals("0", Main.normalizeMouseMode("native"));
+        assertEquals("1", Main.normalizeMouseMode("all"));
+        assertEquals("1", Main.normalizeMouseMode("1"));
+        assertEquals("wheel", Main.normalizeMouseMode("btn"));
+        assertEquals("wheel", Main.normalizeMouseMode("wheel"));
+        assertEquals("select", Main.normalizeMouseMode("select"));
+    }
+}

--- a/src/test/java/com/williamcallahan/chatclient/ui/ConfigPromptScreenPasteTest.java
+++ b/src/test/java/com/williamcallahan/chatclient/ui/ConfigPromptScreenPasteTest.java
@@ -1,0 +1,47 @@
+package com.williamcallahan.chatclient.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.williamcallahan.chatclient.Config;
+import com.williamcallahan.tui4j.compat.bubbletea.Model;
+import com.williamcallahan.tui4j.compat.bubbletea.PasteMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.UpdateResult;
+import org.junit.jupiter.api.Test;
+
+class ConfigPromptScreenPasteTest {
+
+    @Test
+    void pasteInsertsSanitizedSingleLineText() {
+        PromptScreenUnderTest prompt = new PromptScreenUnderTest();
+
+        prompt.update(new PasteMessage("sk-test\r\nline-two\tline-three"));
+
+        assertEquals("sk-test line-two line-three", prompt.currentValue());
+    }
+
+    private static final class PromptScreenUnderTest extends ConfigPromptScreen {
+
+        private PromptScreenUnderTest() {
+            super(new Config(), "placeholder", 256);
+        }
+
+        @Override
+        protected String promptTitle() {
+            return "title";
+        }
+
+        @Override
+        protected String promptBody() {
+            return "body";
+        }
+
+        @Override
+        protected UpdateResult<? extends Model> onSubmit(String value) {
+            return UpdateResult.from(this);
+        }
+
+        private String currentValue() {
+            return textInput.value();
+        }
+    }
+}

--- a/src/test/java/com/williamcallahan/chatclient/ui/ConfigPromptScreenPasteTest.java
+++ b/src/test/java/com/williamcallahan/chatclient/ui/ConfigPromptScreenPasteTest.java
@@ -19,6 +19,15 @@ class ConfigPromptScreenPasteTest {
         assertEquals("sk-test line-two line-three", prompt.currentValue());
     }
 
+    @Test
+    void pasteTrimsBoundaryWhitespaceFromControlCharacters() {
+        PromptScreenUnderTest prompt = new PromptScreenUnderTest();
+
+        prompt.update(new PasteMessage("\n\t sk-test \r\n"));
+
+        assertEquals("sk-test", prompt.currentValue());
+    }
+
     private static final class PromptScreenUnderTest extends ConfigPromptScreen {
 
         private PromptScreenUnderTest() {

--- a/src/test/java/com/williamcallahan/chatclient/ui/PasteRoutingModelTest.java
+++ b/src/test/java/com/williamcallahan/chatclient/ui/PasteRoutingModelTest.java
@@ -1,0 +1,92 @@
+package com.williamcallahan.chatclient.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.williamcallahan.tui4j.compat.bubbles.textarea.Textarea;
+import com.williamcallahan.tui4j.compat.bubbletea.Command;
+import com.williamcallahan.tui4j.compat.bubbletea.KeyPressMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.Message;
+import com.williamcallahan.tui4j.compat.bubbletea.Model;
+import com.williamcallahan.tui4j.compat.bubbletea.PasteMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.UpdateResult;
+import com.williamcallahan.tui4j.compat.lipgloss.color.NoColor;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class PasteRoutingModelTest {
+
+    @Test
+    void routesPasteToRunesWhenStrategySaysToRoute() {
+        RecordingModel delegate = new RecordingModel();
+        PasteRoutingModel model = new PasteRoutingModel(delegate, ignored -> true);
+
+        model.update(new PasteMessage("coffee\nshop"));
+
+        KeyPressMessage keyPress = assertInstanceOf(
+            KeyPressMessage.class,
+            delegate.lastMessage
+        );
+        assertEquals("coffee shop", new String(keyPress.runes()));
+    }
+
+    @Test
+    void leavesPasteUntouchedWhenStrategyDeclinesRoute() {
+        RecordingModel delegate = new RecordingModel();
+        PasteRoutingModel model = new PasteRoutingModel(delegate, ignored -> false);
+
+        model.update(new PasteMessage("coffee"));
+
+        assertInstanceOf(PasteMessage.class, delegate.lastMessage);
+    }
+
+    @Test
+    void applyComposerStylesClearsFocusedCursorLineBackground() {
+        Textarea composer = new Textarea();
+        Object before = styleBackground(composer.focusedStyle().cursorLine());
+        assertFalse(before instanceof NoColor);
+
+        PasteRoutingModel.applyComposerStyles(composer);
+
+        Object after = styleBackground(composer.focusedStyle().cursorLine());
+        assertTrue(after instanceof NoColor);
+    }
+
+    private static final class RecordingModel implements Model {
+
+        private Message lastMessage;
+
+        @Override
+        public Command init() {
+            return null;
+        }
+
+        @Override
+        public UpdateResult<? extends Model> update(Message msg) {
+            lastMessage = msg;
+            return UpdateResult.from(this);
+        }
+
+        @Override
+        public String view() {
+            return "";
+        }
+    }
+
+    private static Object styleBackground(
+        com.williamcallahan.tui4j.compat.lipgloss.Style style
+    ) {
+        try {
+            Field background = style.getClass().getDeclaredField("background");
+            background.setAccessible(true);
+            return background.get(style);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                "Unable to inspect style background",
+                e
+            );
+        }
+    }
+}

--- a/src/test/java/com/williamcallahan/chatclient/ui/PasteRoutingModelTest.java
+++ b/src/test/java/com/williamcallahan/chatclient/ui/PasteRoutingModelTest.java
@@ -54,6 +54,14 @@ class PasteRoutingModelTest {
         assertTrue(after instanceof NoColor);
     }
 
+    @Test
+    void normalizeForSingleLineInputTrimsBoundaryWhitespace() {
+        assertEquals(
+            "coffee shop",
+            PasteRoutingModel.normalizeForSingleLineInput("\n coffee\tshop \r\n")
+        );
+    }
+
     private static final class RecordingModel implements Model {
 
         private Message lastMessage;


### PR DESCRIPTION
## Summary
This PR merges `dev` into `main` with terminal input fixes: paste now works in config and overlay input flows, native terminal copy/paste is the default mouse behavior again, and the composer no longer renders a black active-line background. Follow-up review fixes also harden paste normalization by trimming boundary control-character whitespace and removing duplicated sanitizer logic.

## Changes

### Bug Fixes
- **Config/API-key prompts now accept pasted content reliably** by converting paste events into sanitized rune input (`ConfigPromptScreen.handlePaste` in `src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java`).
- **Places overlay input now handles paste correctly** via routed paste-to-runes behavior while overlay input mode is active (`PasteRoutingModel.update` and `ChatPlacesInputStrategy.shouldRoutePasteAsRunes` in `src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java`).
- **Composer active-line black background is removed** by overriding textarea focused/blurred/base styles to keep terminal-theme consistency (`PasteRoutingModel.applyComposerStyles` in `src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java`).
- **Boundary paste whitespace is now trimmed** so newline/tab wrappers around token-like values no longer leak leading/trailing spaces (`PasteRoutingModel.normalizeForSingleLineInput` in `src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java`).
- **Default mouse mode now preserves native terminal selection/paste** when `BRIEF_MOUSE` is unset or unknown (`Main.normalizeMouseMode` in `src/main/java/com/williamcallahan/chatclient/Main.java`).

### Refactoring
- **Single-line paste sanitization is centralized** by removing duplicated logic from config prompt handling and reusing the shared normalizer (`src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java`, `src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java`).

### Build / Release
- **Runtime app version now comes from build metadata** instead of a hardcoded constant, using filtered `version.properties` during resource processing (`src/main/java/com/williamcallahan/chatclient/AppInfo.java`, `build.gradle.kts`, `src/main/resources/version.properties`).
- **Default project version is bumped to `0.2.0`** for this release train (`build.gradle.kts`).
- **Local Gradle cache noise is removed from git status** by ignoring `.gradle-local/` (`.gitignore`).

### Documentation
- **`BRIEF_MOUSE` docs now list all accepted aliases** (`true`/`false`/`buttons`) to match runtime normalization behavior (`docs/environment-variables-api-keys.md`).

### Tests
- Added coverage for mouse alias normalization and default mode behavior (`src/test/java/com/williamcallahan/chatclient/MainMouseModeTest.java`).
- Added config prompt paste sanitization coverage, including boundary trim behavior (`src/test/java/com/williamcallahan/chatclient/ui/ConfigPromptScreenPasteTest.java`).
- Added routed-paste normalization and composer style behavior coverage (`src/test/java/com/williamcallahan/chatclient/ui/PasteRoutingModelTest.java`).

## Breaking Changes
None

## Validation
- `make lint` (not available in this repo; no `lint` target)
- `GRADLE_USER_HOME=.gradle-local make test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR merges the latest `dev` fixes into `main` for the v0.2.0 release. The changes restore native terminal paste/selection behavior as the default, fix paste handling in prompt flows, remove the black active-line background from the chat composer, and align runtime version metadata with build metadata.

**Key changes:**
- **Paste handling**: Clipboard content in config/API-key prompts is now sanitized to single-line input, and the new `PasteRoutingModel` wrapper enables paste routing for single-line overlay inputs
- **Mouse mode defaults**: `BRIEF_MOUSE` now defaults to native mode (`0`) with normalized aliases (`off`, `native`, `false`, etc.), restoring standard terminal selection/paste behavior
- **Composer styling**: Cursor-line background is cleared via `PasteRoutingModel.applyComposerStyles()` to match terminal theme
- **Version wiring**: Runtime version loads from filtered `version.properties` resource instead of hardcoded constant
- **Version bump**: Default project version updated to `0.2.0`

The implementation is well-tested with comprehensive unit tests covering paste normalization, mouse mode normalization, and composer styling. The previous DRY1 violation has been addressed in commit `54b66b8`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are well-tested, backward compatible, and address specific bugs. The implementation follows project conventions (LOC1 compliance at 195 lines, DRY1 adherence). Tests validate all new behavior including paste normalization, mouse mode defaults, and style application.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| build.gradle.kts | Bumped version to 0.2.0 and added version property expansion to resources |
| src/main/java/com/williamcallahan/chatclient/AppInfo.java | Replaced hardcoded version constant with runtime loading from `version.properties` |
| src/main/java/com/williamcallahan/chatclient/Main.java | Changed default mouse mode to native (0) and added normalization function with multiple aliases |
| src/main/java/com/williamcallahan/chatclient/ui/ConfigPromptScreen.java | Added paste handler that normalizes clipboard content for single-line input |
| src/main/java/com/williamcallahan/chatclient/ui/PasteRoutingModel.java | New wrapper model that routes paste events and applies composer styling using reflection |

</details>



<sub>Last reviewed commit: 704718b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->