### PR TITLE
build: bump version to 0.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.williamcallahan"
-version = findProperty("version")?.toString()?.takeIf { it != "unspecified" } ?: "0.2.1"
+version = findProperty("version")?.toString()?.takeIf { it != "unspecified" } ?: "0.2.2"
 
 java {
     toolchain {


### PR DESCRIPTION
## Summary
Version bump for clean release with single-JAR assets.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps the default fallback version in `build.gradle.kts` from `0.2.1` to `0.2.2` for a clean release with single-JAR assets. No logic, dependency, or configuration changes are included.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line version bump with no functional impact.

Change is a one-line version string update; no logic, API, or dependency modifications are present. No P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| build.gradle.kts | Version fallback bumped from 0.2.1 to 0.2.2; no other changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build.gradle.kts] --> B{findProperty version}
    B -- "set & not 'unspecified'" --> C[Use supplied version]
    B -- "unset or 'unspecified'" --> D[Fallback: 0.2.2]
    C --> E[Build artifact]
    D --> E
```

<sub>Reviews (1): Last reviewed commit: ["build: bump version to 0.2.2"](https://github.com/williamagh/brief/commit/a7eac7fd55bf1f071f6d022cd0369d437a9db4cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27238572)</sub>

<!-- /greptile_comment -->